### PR TITLE
fixes#29 Option to not encode cookie values

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,4 @@ Options object should be a type of `CookieOptions` interface. The object may hav
 - **domain** - {string} - The cookie will be available only for this domain and its sub-domains. For security reasons the user agent will not accept the cookie if the current domain is not a sub-domain of this domain or equal to it.
 - **expires** - {string|Date} - String of the form "Wdy, DD Mon YYYY HH:MM:SS GMT" or a Date object indicating the exact date/time this cookie will expire.
 - **secure** - {boolean} - If `true`, then the cookie will only be available through a secured connection.
+- **storeUnencoded** - {boolean} - If `true`, then the cookie value will not be encoded and will be stored as provided. 

--- a/src/cookie-options.model.ts
+++ b/src/cookie-options.model.ts
@@ -15,10 +15,13 @@
  *   or a Date object indicating the exact date/time this cookie will expire.
  * - **secure** - {boolean} - If `true`, then the cookie will only be available through a
  *   secured connection.
+ * - **storeUnencoded** - {boolean} - If `true`, then the cookie value will not be encoded and 
+ *   will be stored as provided. 
  */
 export interface CookieOptions {
   path?: string;
   domain?: string;
   expires?: string|Date;
   secure?: boolean;
+  storeUnencoded?: boolean;
 }

--- a/src/cookie.service.ts
+++ b/src/cookie.service.ts
@@ -173,8 +173,8 @@ export class CookieService implements ICookieService {
     if (isString(expires)) {
       expires = new Date(expires);
     }
-
-    let str = encodeURIComponent(name) + '=' + encodeURIComponent(value);
+    let cookieValue = opts.storeUnencoded ? value : encodeURIComponent(value);
+    let str = encodeURIComponent(name) + '=' + cookieValue;
     str += opts.path ? ';path=' + opts.path : '';
     str += opts.domain ? ';domain=' + opts.domain : '';
     str += expires ? ';expires=' + expires.toUTCString() : '';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,7 @@ export function mergeOptions(oldOptions: CookieOptions, newOptions?: CookieOptio
     domain: isPresent(newOptions.domain) ? newOptions.domain : oldOptions.domain,
     expires: isPresent(newOptions.expires) ? newOptions.expires : oldOptions.expires,
     secure: isPresent(newOptions.secure) ? newOptions.secure : oldOptions.secure,
+    storeUnencoded: isPresent(newOptions.storeUnencoded) ? newOptions.storeUnencoded : oldOptions.storeUnencoded,
   };
 }
 

--- a/tests/cookie.service.spec.ts
+++ b/tests/cookie.service.spec.ts
@@ -137,4 +137,15 @@ describe('CookieService', () => {
     expect(cookieService.get(key)).toBe(value);
   });
 
+  it('should store unencoded cookie values if requested', () => {
+    let key = 'testCookieKey';
+    let value = 'testCookieValue=unencoded';
+    let opts: CookieOptions = {
+      storeUnencoded: true
+    };
+    cookieService.put(key, value, opts);
+    expect(document.cookie).toBe(`${key}=${value}`);
+    expect(cookieService.get(key)).toBe(value);
+  });
+
 });


### PR DESCRIPTION
A `storeUnencoded` option has been added to CookieOptions so that users can select not to encode
cookie values when they are stored.
Appropriate testing has been added and README file is updated with this new feature.