### PR TITLE
override put function instead of trying to set cookieString

### DIFF
--- a/lib/src/lib/cookie-backend.service.ts
+++ b/lib/src/lib/cookie-backend.service.ts
@@ -14,11 +14,11 @@ export class CookieBackendService extends CookieService {
   }
 
   protected get cookieString(): string {
-    return this.request.cookie || '';
+    return this.request.headers.cookie || '';
   }
 
   protected set cookieString(val: string) {
-    this.request.cookie = val;
+    this.request.headers.cookie = val;
     this.response.cookie = val;
   }
 }

--- a/lib/src/lib/cookie-backend.service.ts
+++ b/lib/src/lib/cookie-backend.service.ts
@@ -3,6 +3,7 @@ import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 
 import { CookieService } from './cookie.service';
 import { CookieOptionsProvider } from './cookie-options-provider';
+import { CookieOptions } from './cookie-options.model';
 
 @Injectable()
 export class CookieBackendService extends CookieService {

--- a/lib/src/lib/cookie-backend.service.ts
+++ b/lib/src/lib/cookie-backend.service.ts
@@ -17,8 +17,13 @@ export class CookieBackendService extends CookieService {
     return this.request.headers.cookie || '';
   }
 
-  protected set cookieString(val: string) {
-    this.request.headers.cookie = val;
-    this.response.cookie = val;
+  put(key: string, value: string, options: CookieOptions = {}) {
+    this.getAll()[key] = value;
+
+    this.request.headers.cookie = Object.keys(this.getAll()).map(key => {
+      return `${key}=${this.get(key)}`;
+    }).join('; ');
+
+    this.response.cookie(key, value, options);
   }
 }


### PR DESCRIPTION
`this.request.cookie` is `undefined`, `this.request.headers.cookie` works like a normal property unlike the browser's `document.cookie`, and `this.response.cookie` is a function.

Since `cookieString` is relying on a `document.cookie` like property and neither express cookie properties satisfy this, I've decided the best fix is to override the `put` function to modify `this.request.headers.cookie` (not just overwrite it) and call `this.response.cookie`