### PR TITLE
es5をtargetにするようにしてみた

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "module": "es2020",
     "lib": [
       "es2018",


### PR DESCRIPTION
 tsconfigのjsのコンパイルターゲットが`es2015`になっていたため、es5にしました。