### PR TITLE
Removes node versions 10 and 15, and adds 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - name: Update chrome


### PR DESCRIPTION
The dependabot angular version update pull requests fail because Angular 12 and greater does not support Node 10.

This pull request
- Removes Node 10 from the test matrix since it is no longer supported..
- Removes Node 15 from the test matrix since it is no longer supported.
- Adds Node 16 to the test matrix.
