### PR TITLE
Correct typing of CookieService.get()

### DIFF
--- a/projects/ngx-cookie/src/lib/cookie.model.ts
+++ b/projects/ngx-cookie/src/lib/cookie.model.ts
@@ -43,7 +43,7 @@ export interface ICookieWriterService {
 
 export interface ICookieService {
   hasKey(key: string): boolean;
-  get(key: string): string;
+  get(key: string): string | undefined;
   getObject(key: string): object | undefined;
   getAll(): object;
   put(key: string, value: string, options?: CookieOptions): void;

--- a/projects/ngx-cookie/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie/src/lib/cookie.service.ts
@@ -36,7 +36,7 @@ export class CookieService implements ICookieService {
    * @param key Id to use for lookup.
    * @returns Raw cookie value.
    */
-  get(key: string): string {
+  get(key: string): string | undefined {
     return this.getAll()?.[key];
   }
 


### PR DESCRIPTION
The following test clarifies that  `CookieService.get()` method can return `undefined` https://github.com/salemdar/ngx-cookie/blob/master/projects/ngx-cookie/src/lib/cookie.service.spec.ts#L29-L33 but the typing doesn't specify that it can return undefined. Hence I propose this change.