### PR TITLE
fix parseCookieString for '; ' situation

### DIFF
--- a/projects/ngx-cookie-backend/src/lib/cookie-backend-writer.service.spec.ts
+++ b/projects/ngx-cookie-backend/src/lib/cookie-backend-writer.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 import { Request, Response } from 'express';
-import { COOKIE_WRITER, ICookieWriterService } from 'ngx-cookie';
+import { COOKIE_WRITER, ICookieWriterService, parseCookieString } from 'ngx-cookie';
 
 import { CookieBackendModule } from './cookie-backend.module';
 
@@ -47,6 +47,18 @@ describe('CookieBackendWriterService', () => {
     const allAsString = service.readAllAsString();
     expect(allAsString).toEqual(cookie);
     expect(response.getHeader).toHaveBeenCalledOnceWith('Set-Cookie');
+  });
+
+  it('should parseCookieString with request header', () => {
+    const cookie = 'myKey1=myValue1; myKey2=myValue2';
+    request.headers.cookie = cookie;
+    const allAsString = service.readAllAsString();
+    const parsed = parseCookieString(allAsString)
+    const expected = {
+      'myKey1': 'myValue1',
+      'myKey2': 'myValue2'
+    };
+    expect(parsed).toEqual(expected);
   });
 
   it('should readAllAsString with response header', () => {

--- a/projects/ngx-cookie/src/lib/utils.ts
+++ b/projects/ngx-cookie/src/lib/utils.ts
@@ -65,18 +65,18 @@ export function parseCookieString(currentCookieString: string): CookieDict {
   let name: string;
   if (currentCookieString !== lastCookieString) {
     lastCookieString = currentCookieString;
-    cookieArray = lastCookieString.split('; ');
+    cookieArray = lastCookieString.split(';');
     lastCookies = {};
     for (i = 0; i < cookieArray.length; i++) {
       cookie = cookieArray[i];
       index = cookie.indexOf('=');
       if (index > 0) {  // ignore nameless cookies
-        name = safeDecodeURIComponent(cookie.substring(0, index));
+        name = safeDecodeURIComponent((cookie.substring(0, index)).trim());
         // the first value that is seen for a cookie is the most
         // specific one.  values for the same cookie name that
         // follow are for less specific paths.
         if (isNil((lastCookies)[name])) {
-          lastCookies[name] = safeDecodeURIComponent(cookie.substring(index + 1));
+          lastCookies[name] = safeDecodeURIComponent((cookie.substring(index + 1)).trim());
         }
       }
     }


### PR DESCRIPTION
I'm Wilson, 

Bug: I use the ngx-cookie & ngx-cookie-backend in my Angular Universal Project, but found an issue. When my website(localhost:4200) have 3 cookies but in server-side console.log with ngx-cookie-backend service only 1 cookie

![image](https://user-images.githubusercontent.com/4183364/167305253-96d37c12-6d49-4b9a-80f3-6256aebe01b0.png)

![image](https://user-images.githubusercontent.com/4183364/167305278-765a2539-119e-4a3b-ad6b-2960685bc35a.png)

![image](https://user-images.githubusercontent.com/4183364/167305284-71e298ce-1808-4148-bea2-9688ae2ae11a.png)
