### PR TITLE
Updating the ngx-cookie dependency to 6.0.1.

### DIFF
--- a/projects/ngx-cookie-backend/package.json
+++ b/projects/ngx-cookie-backend/package.json
@@ -32,8 +32,8 @@
     "@angular/common": ">=12.0.0",
     "@angular/core": ">=12.0.0",
     "@nguniversal/express-engine": ">=12.0.0",
-    "ngx-cookie": "6.0.0"
-},
+    "ngx-cookie": "6.0.1"
+  },
   "dependencies": {
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
This is disallowing us to update to the latest version of ngx-cookie and thus preventing the resolution provided in 6.0.1 for issue #387. 